### PR TITLE
issue-21: Use readline to set vi editing-mode

### DIFF
--- a/data/readline/.inputrc
+++ b/data/readline/.inputrc
@@ -11,6 +11,9 @@
 #set output-meta on
 
 $if Bash
+  # vi editing-mode
+  set editing-mode vi
+
   # Don't ring bell on completion
   #set bell-style none
 

--- a/data/readline/readline.sh
+++ b/data/readline/readline.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! usr/bin/env bash
 
 bind -f $HOME/.inputrc


### PR DESCRIPTION
  * Fixes #21

Signed-off-by: Mike Detwiler <mike@detwiler.io>