### PR TITLE
Prevent tar from adding exteneded attributes files on Mac

### DIFF
--- a/data/bash/common/profile.d/Makefile.am
+++ b/data/bash/common/profile.d/Makefile.am
@@ -10,11 +10,16 @@ info = info.sh
 gnulib = gnulib.sh
 go = go.sh
 gpg = gpg.sh
+macosx = macosx.sh
 
 # static data/scripts (not generated; require explicit distribution)
 static_data = $(bash_completion) \
 	      $(bash) \
 	      $(gpg)
+
+if HOST_OS_DARWIN
+static_data += $(macosx)
+endif
 
 dist_profile_DATA = $(static_data)
 

--- a/data/bash/common/profile.d/macosx.sh
+++ b/data/bash/common/profile.d/macosx.sh
@@ -1,0 +1,4 @@
+# Mac OS X environment settings
+
+# prevent tar from adding mac's extended attribute file to archives
+export COPYFILE_DISABLE=true


### PR DESCRIPTION
Title says it all.