### PR TITLE
Install xdg-configure Script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,26 +2,30 @@
 
 SUBDIRS = data
 
+bootstrap_funclib = bootstrap-funclib.sh
 pkg_name = $(top_srcdir)/.package-name
 pkg_release = $(PACKAGE)-release
 version_stamp = $(top_srcdir)/.version
+xdg_configure = xdg-configure
 
 ACLOCAL_AMFLAGS = -I m4 -I .quickhatch/m4
 
 BUILT_SOURCES = $(pkg_name) \
 		$(version_stamp)
 
+dist_bin_SCRIPTS = $(xdg_configure)
+
 dist_pkgconf_DATA = $(pkg_release)
+
+dist_pkgdata_DATA = $(bootstrap_funclib)
 
 CLEANFILES = $(pkg_name) \
 	     $(pkg_release)
 
 EXTRA_DIST = m4/gnulib-cache.m4 \
-	     bootstrap-funclib.sh \
 	     $(pkg_name) \
 	     README.md \
-	     $(version_stamp) \
-	     xdg-configure
+	     $(version_stamp)
 
 AM_DISTCHECK_CONFIGURE_FLAGS = EC_HOME=$(top_distdir)
 
@@ -43,4 +47,14 @@ gen-ChangeLog:
 dist-tarball-version:
 	$(AM_V_GEN)echo '$(VERSION)' > $(distdir)/.tarball-version
 
+# sed command to build data/scripts
+EDIT = -e 's:@PACKAGE_STRING[@]:$(PACKAGE_STRING):g' \
+       -e 's:@pkgdatadir[@]:$(pkgdatadir):g'
+
+install-xdg-configure-hook:
+	$(AM_V_GEN)cd $(DESTDIR)$(bindir) && \
+	  $(SED) --in-place $(EDIT) $(xdg_configure)
+
 dist-hook: gen-ChangeLog dist-tarball-version
+
+install-data-hook: install-xdg-configure-hook

--- a/bootstrap-funclib.sh
+++ b/bootstrap-funclib.sh
@@ -1,6 +1,6 @@
 # A library of shell functions for autopull.sh, autogen.sh, and bootstrap.
 
-scriptlibversion=2025-06-10.02; # UTC
+scriptlibversion=2025-11-12.14; # UTC
 
 # Copyright (C) 2003-2025 Free Software Foundation, Inc.
 #
@@ -35,7 +35,7 @@ export LC_ALL
 # Honor $PERL, but work even if there is none.
 PERL="${PERL-perl}"
 
-default_gnulib_url=https://git.savannah.gnu.org/git/gnulib.git
+default_gnulib_url=https://https.git.savannah.gnu.org/git/gnulib.git
 
 # Copyright year, for the --version output.
 copyright_year=`echo "$scriptlibversion" | sed -e 's/[^0-9].*//'`
@@ -824,7 +824,7 @@ autopull()
     elif check_exists git-merge-changelog; then
       echo "$0: initializing git-merge-changelog driver"
       git config merge.merge-changelog.name 'GNU-style ChangeLog merge driver'
-      git config merge.merge-changelog.driver 'git-merge-changelog %O %A %B'
+      git config merge.merge-changelog.driver 'git-merge-changelog %O %A %B "%Y"'
     else
       echo "$0: consider installing git-merge-changelog from gnulib"
     fi

--- a/xdg-configure
+++ b/xdg-configure
@@ -7,7 +7,17 @@ me=$(basename $0)
 medir=$(dirname $0)
 
 # use gnulib's boostrap function library
-source "$medir"/bootstrap-funclib.sh
+if [[ -f "$medir"/bootstrap-funclib.sh ]]; then
+    source "$medir"/bootstrap-funclib.sh
+elif [[ -f @pkgdatadir@/bootstrap-funclib.sh ]]; then
+    source @pkgdatadir@/bootstrap-funclib.sh
+fi
+
+function print_version()
+{
+  local utility="$1"
+  printf "%s\n" "$utility (@PACKAGE_STRING@)"
+} # print_version()
 
 function usage()
 {
@@ -15,14 +25,14 @@ function usage()
 
 	Usage: $me [OPTIONS] -- [CONFIGURE-ARG]...
 
-	Call envconf's configure script with key installation directory options
+	Call a package's configure script with installation directory options
 	aligned with the XDG Base Directory Specification. Optionally, compute
 	XDG-ish installation directory options that allow isolation of this
-	envconf installation from other envconf installations. In this way,
-	envconf installations can reside alongside each other on a per-host,
+	package installation from other installations of the package. In this way,
+	package installations can reside alongside each other on a per-host,
 	per-toolbox, or per-distro basis. This can help mitigate issues that
-	arise when a home directory is shared across multiple hosts, distros,
-	or tooolboxes.
+	arise when a package is installed in a user's home directory, and the home
+	directory is shared across multiple hosts, distros, or toolboxes.
 
 
 	Options:
@@ -33,6 +43,7 @@ function usage()
 	  --dry-run		display installation directories, but do
 	  			not call configure
 	  --help		display this help and exit
+	  --version		display version
 
 	Arguments:
 
@@ -109,7 +120,7 @@ function display_config()
 }
 
 short_opts='dht'
-long_opts='distro,dry-run,help,host,toolbox'
+long_opts='distro,dry-run,help,host,toolbox,version'
 
 if ! options=$(getopt --options $short_opts --longoptions $long_opts --name $me -- "$@"); then
   die "Option parsing failed"
@@ -134,6 +145,7 @@ while true; do
     --dry-run) dryrun=true; shift ;;
     -h|--host) config_host; shift ;;
     -t|--toolbox) config_toolbox; shift ;;
+    --version) print_version $me; exit 0 ;;
     --) shift; break ;;
     *) die 'Option parsing failed' ;;
   esac


### PR DESCRIPTION
Install `xdg-configure`, so it can be used to configure other packages.

Also, update `gnulib` submodule to latest version and sync bootstrap scripts.

Closes #144 